### PR TITLE
pyup: fix security issues codecov=2.0.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ black==19.10b0            # via -r ./requirements.in/linting.txt
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via doc8, requests
 click==7.0                # via -r ./requirements.in/base.txt, black, pip-tools
-codecov==2.0.15           # via -r ./requirements.in/test.txt
+codecov==2.0.16           # via -r ./requirements.in/test.txt
 coverage==5.0.3           # via -r ./requirements.in/test.txt, codecov, pytest-cov
 distlib==0.3.0            # via virtualenv
 doc8==0.8.0               # via -r ./requirements.in/docs.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,7 +15,7 @@ black==19.10b0            # via -r ./requirements.in/linting.txt
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via doc8, requests
 click==7.0                # via -r ./requirements.in/base.txt, black, pip-tools
-codecov==2.0.15           # via -r ./requirements.in/test.txt
+codecov==2.0.16           # via -r ./requirements.in/test.txt
 coverage==5.0.3           # via -r ./requirements.in/test.txt, codecov, pytest-cov
 distlib==0.3.0            # via virtualenv
 doc8==0.8.0               # via -r ./requirements.in/docs.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,7 +9,7 @@ appdirs==1.4.3            # via virtualenv
 attrs==19.3.0             # via pytest
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-codecov==2.0.15           # via -r ./requirements.in/test.txt
+codecov==2.0.16           # via -r ./requirements.in/test.txt
 coverage==5.0.3           # via -r ./requirements.in/test.txt, codecov, pytest-cov
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv


### PR DESCRIPTION
Bump `codecov=2.0.15` to `codecov=2.0.16` fixing its security issues. 